### PR TITLE
#7 Add dynamic navigation based on screen size

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,12 +52,15 @@ dependencies {
     implementation composeBom
     androidTestImplementation composeBom
 
-    implementation 'androidx.core:core-ktx:1.9.0'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.5.1'
-    implementation 'androidx.activity:activity-compose:1.6.1'
     implementation 'androidx.compose.ui:ui'
     implementation 'androidx.compose.ui:ui-tooling-preview'
     implementation 'androidx.compose.material3:material3'
+    implementation 'androidx.compose.material:material-icons-extended'
+    implementation 'androidx.compose.material3:material3-window-size-class'
+    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.5.1'
+    implementation 'androidx.activity:activity-compose:1.6.1'
+    implementation 'androidx.navigation:navigation-compose:2.5.3'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'

--- a/app/src/main/java/com/example/android/picover/MainActivity.kt
+++ b/app/src/main/java/com/example/android/picover/MainActivity.kt
@@ -3,38 +3,75 @@ package com.example.android.picover
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
-import com.example.android.picover.ui.theme.PicoverTheme
+import androidx.navigation.compose.rememberNavController
+import com.example.android.picover.presentation.navigation.NavigationItem
+import com.example.android.picover.presentation.navigation.NavigationType
+import com.example.android.picover.presentation.navigation.PicoverNavigationBar
+import com.example.android.picover.presentation.navigation.PicoverNavigationDrawer
+import com.example.android.picover.presentation.navigation.PicoverNavigationRail
+import com.example.android.picover.presentation.ui.theme.PicoverTheme
 
+@OptIn(ExperimentalMaterial3WindowSizeClassApi::class, ExperimentalMaterial3Api::class)
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
             PicoverTheme {
-                // A surface container using the 'background' color from the theme
-                Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
-                    Greeting("Picover")
+                val windowSize = calculateWindowSizeClass(this)
+                val navigationType = NavigationType.fromWindowSize(windowSize)
+                val navController = rememberNavController()
+                val navigationItems = listOf(
+                    NavigationItem.Home,
+                    NavigationItem.Camera,
+                    NavigationItem.Profile
+                )
+
+                Scaffold {
+                    AnimatedVisibility(
+                        visible = navigationType == NavigationType.NAVIGATION_BAR
+                    ) {
+                        PicoverNavigationBar(
+                            items = navigationItems,
+                            navController = navController,
+                            onItemClick = {
+                                navController.navigate(it.route)
+                            },
+                            modifier = Modifier.padding(it)
+                        )
+                    }
+                    AnimatedVisibility(
+                        visible = navigationType == NavigationType.NAVIGATION_RAIL
+                    ) {
+                        PicoverNavigationRail(
+                            items = navigationItems,
+                            navController = navController,
+                            onItemClick = {
+                                navController.navigate(it.route)
+                            },
+                            modifier = Modifier.padding(it)
+                        )
+                    }
+                    AnimatedVisibility(
+                        visible = navigationType == NavigationType.NAVIGATION_DRAWER
+                    ) {
+                        PicoverNavigationDrawer(
+                            items = navigationItems,
+                            navController = navController,
+                            onItemClick = {
+                                navController.navigate(it.route)
+                            },
+                            modifier = Modifier.padding(it)
+                        )
+                    }
                 }
             }
         }
-    }
-}
-
-@Composable
-fun Greeting(name: String) {
-    Text(text = "Hello $name!")
-}
-
-@Preview(showBackground = true)
-@Composable
-fun DefaultPreview() {
-    PicoverTheme {
-        Greeting("Picover")
     }
 }

--- a/app/src/main/java/com/example/android/picover/presentation/CameraScreen.kt
+++ b/app/src/main/java/com/example/android/picover/presentation/CameraScreen.kt
@@ -1,0 +1,22 @@
+package com.example.android.picover.presentation
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.example.android.picover.R
+
+@Composable
+fun CameraScreen() {
+    Box(
+        modifier = Modifier.fillMaxSize()
+    ) {
+        Text(
+            text = stringResource(id = R.string.camera),
+            modifier = Modifier.align(Alignment.Center)
+        )
+    }
+}

--- a/app/src/main/java/com/example/android/picover/presentation/HomeScreen.kt
+++ b/app/src/main/java/com/example/android/picover/presentation/HomeScreen.kt
@@ -1,0 +1,22 @@
+package com.example.android.picover.presentation
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.example.android.picover.R
+
+@Composable
+fun HomeScreen() {
+    Box(
+        modifier = Modifier.fillMaxSize()
+    ) {
+        Text(
+            text = stringResource(id = R.string.home),
+            modifier = Modifier.align(Alignment.Center)
+        )
+    }
+}

--- a/app/src/main/java/com/example/android/picover/presentation/ProfileScreen.kt
+++ b/app/src/main/java/com/example/android/picover/presentation/ProfileScreen.kt
@@ -1,0 +1,22 @@
+package com.example.android.picover.presentation
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.example.android.picover.R
+
+@Composable
+fun ProfileScreen() {
+    Box(
+        modifier = Modifier.fillMaxSize()
+    ) {
+        Text(
+            text = stringResource(id = R.string.profile),
+            modifier = Modifier.align(Alignment.Center)
+        )
+    }
+}

--- a/app/src/main/java/com/example/android/picover/presentation/navigation/NavigationItem.kt
+++ b/app/src/main/java/com/example/android/picover/presentation/navigation/NavigationItem.kt
@@ -1,0 +1,33 @@
+package com.example.android.picover.presentation.navigation
+
+import androidx.annotation.StringRes
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.PhotoCamera
+import androidx.compose.ui.graphics.vector.ImageVector
+import com.example.android.picover.R
+
+sealed class NavigationItem(
+    @StringRes val labelResId: Int,
+    val icon: ImageVector,
+    val route: String
+) {
+    object Home : NavigationItem(
+        labelResId = R.string.home,
+        icon = Icons.Filled.Home,
+        route = "home"
+    )
+
+    object Camera : NavigationItem(
+        labelResId = R.string.camera,
+        icon = Icons.Filled.PhotoCamera,
+        route = "camera"
+    )
+
+    object Profile : NavigationItem(
+        labelResId = R.string.profile,
+        icon = Icons.Filled.Person,
+        route = "profile"
+    )
+}

--- a/app/src/main/java/com/example/android/picover/presentation/navigation/NavigationType.kt
+++ b/app/src/main/java/com/example/android/picover/presentation/navigation/NavigationType.kt
@@ -1,0 +1,18 @@
+package com.example.android.picover.presentation.navigation
+
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+
+enum class NavigationType {
+    NAVIGATION_BAR,
+    NAVIGATION_RAIL,
+    NAVIGATION_DRAWER;
+
+    companion object {
+        fun fromWindowSize(windowSize: WindowSizeClass) = when (windowSize.widthSizeClass) {
+            WindowWidthSizeClass.Medium -> NAVIGATION_RAIL
+            WindowWidthSizeClass.Expanded -> NAVIGATION_DRAWER
+            else -> NAVIGATION_BAR
+        }
+    }
+}

--- a/app/src/main/java/com/example/android/picover/presentation/navigation/PicoverNavHost.kt
+++ b/app/src/main/java/com/example/android/picover/presentation/navigation/PicoverNavHost.kt
@@ -1,0 +1,33 @@
+package com.example.android.picover.presentation.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import com.example.android.picover.presentation.CameraScreen
+import com.example.android.picover.presentation.HomeScreen
+import com.example.android.picover.presentation.ProfileScreen
+
+@Composable
+fun PicoverNavHost(
+    modifier: Modifier,
+    navController: NavHostController,
+    startDestination: String
+) {
+    NavHost(
+        modifier = modifier,
+        navController = navController,
+        startDestination = startDestination
+    ) {
+        composable("home") {
+            HomeScreen()
+        }
+        composable("camera") {
+            CameraScreen()
+        }
+        composable("profile") {
+            ProfileScreen()
+        }
+    }
+}

--- a/app/src/main/java/com/example/android/picover/presentation/navigation/PicoverNavigationBar.kt
+++ b/app/src/main/java/com/example/android/picover/presentation/navigation/PicoverNavigationBar.kt
@@ -1,0 +1,48 @@
+package com.example.android.picover.presentation.navigation
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.currentBackStackEntryAsState
+
+@Composable
+fun PicoverNavigationBar(
+    items: List<NavigationItem>,
+    navController: NavHostController,
+    modifier: Modifier = Modifier,
+    onItemClick: (NavigationItem) -> Unit
+) {
+    val backStackEntry = navController.currentBackStackEntryAsState()
+
+    Column {
+        PicoverNavHost(
+            modifier = modifier.weight(1f),
+            navController = navController,
+            startDestination = NavigationItem.Home.route
+        )
+        NavigationBar(modifier = Modifier.fillMaxWidth()) {
+            items.forEach { item ->
+                NavigationBarItem(
+                    selected = item.route == backStackEntry.value?.destination?.route,
+                    onClick = { onItemClick(item) },
+                    icon = {
+                        Icon(
+                            imageVector = item.icon,
+                            contentDescription = stringResource(id = item.labelResId)
+                        )
+                    },
+                    label = {
+                        Text(text = stringResource(id = item.labelResId))
+                    }
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/android/picover/presentation/navigation/PicoverNavigationDrawer.kt
+++ b/app/src/main/java/com/example/android/picover/presentation/navigation/PicoverNavigationDrawer.kt
@@ -1,0 +1,78 @@
+package com.example.android.picover.presentation.navigation
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationDrawerItem
+import androidx.compose.material3.NavigationDrawerItemDefaults
+import androidx.compose.material3.PermanentDrawerSheet
+import androidx.compose.material3.PermanentNavigationDrawer
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.currentBackStackEntryAsState
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PicoverNavigationDrawer(
+    items: List<NavigationItem>,
+    navController: NavHostController,
+    modifier: Modifier = Modifier,
+    onItemClick: (NavigationItem) -> Unit
+) {
+    val backStackEntry = navController.currentBackStackEntryAsState()
+
+    PermanentNavigationDrawer(
+        drawerContent = {
+            PermanentDrawerSheet(
+                modifier = modifier.width(240.dp)
+            ) {
+                Column(
+                    modifier = Modifier
+                        .wrapContentWidth()
+                        .fillMaxHeight()
+                        .background(MaterialTheme.colorScheme.inverseOnSurface)
+                        .padding(12.dp)
+                ) {
+                    items.forEach { item ->
+                        NavigationDrawerItem(
+                            label = {
+                                Text(
+                                    text = stringResource(id = item.labelResId),
+                                    modifier = Modifier.padding(horizontal = 16.dp)
+                                )
+                            },
+                            selected = item.route == backStackEntry.value?.destination?.route,
+                            onClick = { onItemClick(item) },
+                            icon = {
+                                Icon(
+                                    imageVector = item.icon,
+                                    contentDescription = stringResource(id = item.labelResId)
+                                )
+                            },
+                            colors = NavigationDrawerItemDefaults.colors(
+                                unselectedContainerColor = Color.Transparent
+                            )
+                        )
+                    }
+                }
+            }
+        },
+    ) {
+        PicoverNavHost(
+            modifier = modifier,
+            navController = navController,
+            startDestination = NavigationItem.Home.route
+        )
+    }
+}

--- a/app/src/main/java/com/example/android/picover/presentation/navigation/PicoverNavigationRail.kt
+++ b/app/src/main/java/com/example/android/picover/presentation/navigation/PicoverNavigationRail.kt
@@ -1,0 +1,47 @@
+package com.example.android.picover.presentation.navigation
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationRail
+import androidx.compose.material3.NavigationRailItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.currentBackStackEntryAsState
+
+@Composable
+fun PicoverNavigationRail(
+    items: List<NavigationItem>,
+    navController: NavHostController,
+    modifier: Modifier = Modifier,
+    onItemClick: (NavigationItem) -> Unit
+) {
+    val backStackEntry = navController.currentBackStackEntryAsState()
+
+    Row {
+        NavigationRail {
+            items.forEach { item ->
+                NavigationRailItem(
+                    selected = item.route == backStackEntry.value?.destination?.route,
+                    onClick = { onItemClick(item) },
+                    icon = {
+                        Icon(
+                            imageVector = item.icon,
+                            contentDescription = stringResource(id = item.labelResId)
+                        )
+                    },
+                    label = {
+                        Text(text = stringResource(id = item.labelResId))
+                    }
+                )
+            }
+        }
+        PicoverNavHost(
+            modifier = modifier,
+            navController = navController,
+            startDestination = NavigationItem.Home.route
+        )
+    }
+}

--- a/app/src/main/java/com/example/android/picover/presentation/ui/theme/Color.kt
+++ b/app/src/main/java/com/example/android/picover/presentation/ui/theme/Color.kt
@@ -1,4 +1,4 @@
-package com.example.android.picover.ui.theme
+package com.example.android.picover.presentation.ui.theme
 
 import androidx.compose.ui.graphics.Color
 

--- a/app/src/main/java/com/example/android/picover/presentation/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/android/picover/presentation/ui/theme/Theme.kt
@@ -1,5 +1,4 @@
-
-package com.example.android.picover.ui.theme
+package com.example.android.picover.presentation.ui.theme
 
 import android.app.Activity
 import android.os.Build

--- a/app/src/main/java/com/example/android/picover/presentation/ui/theme/Type.kt
+++ b/app/src/main/java/com/example/android/picover/presentation/ui/theme/Type.kt
@@ -1,4 +1,4 @@
-package com.example.android.picover.ui.theme
+package com.example.android.picover.presentation.ui.theme
 
 import androidx.compose.material3.Typography
 import androidx.compose.ui.text.TextStyle

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,6 @@
 <resources>
     <string name="app_name">Picover</string>
+    <string name="home">Home</string>
+    <string name="camera">Camera</string>
+    <string name="profile">Profile</string>
 </resources>


### PR DESCRIPTION
Add dynamic navigation depending on the current screen size based on Material 3 design guidelines. Of course, we can change the breakpoints of each type to suit our needs.