### PR TITLE
#21 In settings or other place activity from Oss-licenses

### DIFF
--- a/app/src/main/kotlin/com/example/android/picover/presentation/ProfileDrawerContent.kt
+++ b/app/src/main/kotlin/com/example/android/picover/presentation/ProfileDrawerContent.kt
@@ -1,0 +1,27 @@
+package com.example.android.picover.presentation
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalDrawerSheet
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.intive.picover.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ProfileDrawerContent() {
+	ModalDrawerSheet {
+		Box(
+			modifier = Modifier.fillMaxSize(),
+		) {
+			Text(
+				text = stringResource(R.string.Profile),
+				modifier = Modifier.align(Alignment.Center),
+			)
+		}
+	}
+}

--- a/app/src/main/kotlin/com/intive/picover/main/navigation/view/PicoverNavigationBar.kt
+++ b/app/src/main/kotlin/com/intive/picover/main/navigation/view/PicoverNavigationBar.kt
@@ -1,37 +1,60 @@
 package com.intive.picover.main.navigation.view
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.DrawerState
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
+import com.example.android.picover.presentation.ProfileDrawerContent
 import com.intive.picover.main.navigation.model.NavigationItem
+import kotlinx.coroutines.launch
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PicoverNavigationBar(
 	items: List<NavigationItem>,
 	navController: NavHostController,
+	drawerState: DrawerState,
 	modifier: Modifier = Modifier,
 	onItemClick: (NavigationItem) -> Unit,
 ) {
 	val backStackEntry = navController.currentBackStackEntryAsState()
-
 	Column {
-		PicoverNavHost(
+		ModalNavigationDrawer(
+			drawerContent = { ProfileDrawerContent() },
+			drawerState = drawerState,
+			gesturesEnabled = drawerState.isOpen,
 			modifier = modifier.weight(1f),
-			navController = navController,
-			startDestination = NavigationItem.Home.route,
-		)
+		) {
+			val coroutineScope = rememberCoroutineScope()
+			BackHandler(enabled = drawerState.isOpen) {
+				coroutineScope.launch { drawerState.close() }
+			}
+			PicoverNavHost(
+				modifier = modifier.weight(1f),
+				navController = navController,
+				startDestination = NavigationItem.Home.route,
+			)
+		}
 		NavigationBar(modifier = Modifier.fillMaxWidth()) {
 			items.forEach { item ->
 				NavigationBarItem(
-					selected = item.route == backStackEntry.value?.destination?.route,
+					selected = if (item is NavigationItem.Profile) {
+						drawerState.isOpen
+					} else {
+						item.route == backStackEntry.value?.destination?.route && drawerState.isClosed
+					},
 					onClick = { onItemClick(item) },
 					icon = {
 						Icon(

--- a/app/src/main/kotlin/com/intive/picover/main/view/MainActivity.kt
+++ b/app/src/main/kotlin/com/intive/picover/main/view/MainActivity.kt
@@ -5,10 +5,13 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.rememberDrawerState
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.rememberNavController
 import com.intive.picover.main.navigation.model.NavigationItem
@@ -18,10 +21,12 @@ import com.intive.picover.main.navigation.view.PicoverNavigationDrawer
 import com.intive.picover.main.navigation.view.PicoverNavigationRail
 import com.intive.picover.main.theme.PicoverTheme
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3WindowSizeClassApi::class, ExperimentalMaterial3Api::class)
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)
 		setContent {
@@ -34,18 +39,25 @@ class MainActivity : ComponentActivity() {
 					NavigationItem.Camera,
 					NavigationItem.Profile,
 				)
-
 				Scaffold {
 					AnimatedVisibility(
 						visible = navigationType == NavigationType.NAVIGATION_BAR,
 					) {
+						val coroutineScope = rememberCoroutineScope()
+						val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
 						PicoverNavigationBar(
 							items = navigationItems,
 							navController = navController,
 							onItemClick = {
-								navController.navigate(it.route)
+								if (it is NavigationItem.Profile) {
+									coroutineScope.launch { drawerState.open() }
+								} else {
+									coroutineScope.launch { drawerState.close() }
+									navController.navigate(it.route)
+								}
 							},
 							modifier = Modifier.padding(it),
+							drawerState = drawerState,
 						)
 					}
 					AnimatedVisibility(


### PR DESCRIPTION

https://user-images.githubusercontent.com/49060907/218848693-c077eb62-dcbe-4f4b-8bb0-435107eaefc8.mp4

This is quite hacky :) modal navigation drawer is not a part of our navigation, it is shown when profile is clicked and then,  back button is overridden for closing it. It is also closed when we are changing the navigation item from the bar.

This solution applies only for navigation bar.