### PR TITLE
#79 Add coroutine test extension

### DIFF
--- a/app/src/test/kotlin/com/intive/picover/common/coroutines/CoroutineTestExtension.kt
+++ b/app/src/test/kotlin/com/intive/picover/common/coroutines/CoroutineTestExtension.kt
@@ -1,0 +1,22 @@
+package com.intive.picover.common.coroutines
+
+import io.kotest.core.listeners.AfterSpecListener
+import io.kotest.core.listeners.BeforeSpecListener
+import io.kotest.core.spec.Spec
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CoroutineTestExtension : BeforeSpecListener, AfterSpecListener {
+
+	override suspend fun beforeSpec(spec: Spec) {
+		Dispatchers.setMain(UnconfinedTestDispatcher())
+	}
+
+	override suspend fun afterSpec(spec: Spec) {
+		Dispatchers.resetMain()
+	}
+}


### PR DESCRIPTION
This will be needed for coroutines tests -> usage is very simple (described here: https://kotest.io/docs/framework/extensions/extensions-introduction.html)

I assume that we don't want to have it on project level config, as it won't be needed in every test.