### PR TITLE
#79 Add kotlin reflect

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -77,5 +77,8 @@ dependencies {
 	debugImplementation(libs.compose.ui.tooling)
 	testImplementation(libs.test.kotest.runner)
 	testImplementation(libs.test.mockk)
+	testCompileOnly("org.jetbrains.kotlin:kotlin-reflect:1.8.20") {
+		because("Needed to locally trigger single kotest test - check new versions of kotlin and kotest plugins to fix this workaround")
+	}
 }
 


### PR DESCRIPTION
One and only solution I've found for having a possibility to trigger single test when NOT using plugin "window"