### PR TITLE
#64 Optimize CI

### DIFF
--- a/.github/workflows/default_branch_verification.yml
+++ b/.github/workflows/default_branch_verification.yml
@@ -7,16 +7,7 @@ on:
 jobs:
 
   build:
-    runs-on: ubuntu-latest
-    container: gradle:8.0.0-jdk17
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@v2.0.10
-      - name: Read google-service.json
-        env:
-          FIREBASE_GOOGLE_SERVICE: ${{ secrets.FIREBASE_GOOGLE_SERVICE }}
-        run: echo $FIREBASE_GOOGLE_SERVICE > app/src/google-services.json
-      - name: Build with Gradle
-        run: ./gradlew build
+    uses: ./.github/workflows/setup_build_environment.yml
+    with:
+      command: ./gradlew build
+    secrets: inherit

--- a/.github/workflows/pull_request_verification.yml
+++ b/.github/workflows/pull_request_verification.yml
@@ -2,7 +2,6 @@ name: Pull Request verification
 on: pull_request
 
 jobs:
-
   branch-name:
     runs-on: ubuntu-latest
     steps:
@@ -21,21 +20,25 @@ jobs:
       - name: Check correct commit message
         run: ./.github/scripts/commit/checkCommitMessage.sh
 
+  lint-check:
+    uses: ./.github/workflows/setup_build_environment.yml
+    with:
+      command: ./gradlew lintDebug
+    secrets: inherit
+
+  ktlint-check:
+    uses: ./.github/workflows/setup_build_environment.yml
+    with:
+      command: ./gradlew ktlintCheck
+
   build:
-    runs-on: ubuntu-latest
-    container: gradle:8.0.0-jdk17
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@v2.0.10
-      - name: Read google-service.json
-        env:
-          FIREBASE_GOOGLE_SERVICE: ${{ secrets.FIREBASE_GOOGLE_SERVICE }}
-        run: echo $FIREBASE_GOOGLE_SERVICE > app/src/google-services.json
-      - name: Check lint
-        run: ./gradlew lintDebug
-      - name: Check ktlint
-        run: ./gradlew ktlintCheck
-      - name: Build with Gradle
-        run: ./gradlew build
+    uses: ./.github/workflows/setup_build_environment.yml
+    with:
+      command: ./gradlew assemble
+    secrets: inherit
+
+  tests:
+    uses: ./.github/workflows/setup_build_environment.yml
+    with:
+      command: ./gradlew test
+    secrets: inherit

--- a/.github/workflows/setup_build_environment.yml
+++ b/.github/workflows/setup_build_environment.yml
@@ -1,0 +1,24 @@
+name: Setup Build Environment
+
+on:
+  workflow_call:
+    inputs:
+      command:
+        required: true
+        type: string
+
+jobs:
+  setup-build-environment:
+    runs-on: ubuntu-latest
+    container: gradle:8.0.0-jdk17
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2.0.10
+      - name: Read google-service.json
+        env:
+          FIREBASE_GOOGLE_SERVICE: ${{ secrets.FIREBASE_GOOGLE_SERVICE }}
+        run: echo $FIREBASE_GOOGLE_SERVICE > app/src/google-services.json
+      - name: Execute command
+        run: ${{ inputs.command }}


### PR DESCRIPTION
## Docker mingc/android-build-box:latest
<p float="left" align="center">
  <img src="https://github.com/intive/Picover/assets/57491794/41471173-2e43-4804-a353-e2805f73e32c" width="500" title="android-build-box">
</p>

## Gradle Docker with extra install Android SDK
<p float="left" align="center">
  <img src="https://github.com/intive/Picover/assets/57491794/3df74cba-44c6-401b-a51e-d2fab1b4ece4" width="500" title="gradle">
</p>

## Documentation about [limitations ](https://docs.github.com/en/actions/using-workflows/reusing-workflows#limitations):
* You can connect up to four levels of workflows. For more information, see "[Nesting reusable workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows#nesting-reusable-workflows)."

* You can call a maximum of 20 reusable workflows from a single workflow file. This limit includes any trees of nested reusable workflows that may be called starting from your top-level caller workflow file.
For example, top-level-caller-workflow.yml → called-workflow-1.yml → called-workflow-2.yml counts as 2 reusable workflows.

* Any environment variables set in an env context defined at the workflow level in the caller workflow are not propagated to the called workflow. For more information, see "[Variables](https://docs.github.com/en/actions/learn-github-actions/variables)" and "[Contexts](https://docs.github.com/en/actions/learn-github-actions/contexts#env-context)."
* Similarly, environment variables set in the env context, defined in the called workflow, are not accessible in the env context of the caller workflow. Instead, you must use outputs of the reusable workflow. For more information, see "[Reusing workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows#using-outputs-from-a-reusable-workflow).
* To reuse variables in multiple workflows, set them at the organization, repository, or environment levels and reference them using the vars context. For more information see "[Variables](https://docs.github.com/en/actions/learn-github-actions/variables)" and "[Contexts](https://docs.github.com/en/actions/learn-github-actions/contexts#vars-context)."
* **Reusable workflows are called directly within a job, and not from within a job step. You cannot, therefore, use GITHUB_ENV to pass values to job steps in the caller workflow.**
