### PR TITLE
#444 3 navigation button overlaps in the Party Bottom Sheet

### DIFF
--- a/app/src/main/kotlin/com/intive/picover/common/bottomsheet/PicoverModalBottomSheet.kt
+++ b/app/src/main/kotlin/com/intive/picover/common/bottomsheet/PicoverModalBottomSheet.kt
@@ -1,0 +1,28 @@
+package com.intive.picover.common.bottomsheet
+
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PicoverModalBottomSheet(
+	onDismissRequest: () -> Unit,
+
+	content: @Composable (ColumnScope.(bottomSheetModifier: Modifier) -> Unit),
+
+) {
+	ModalBottomSheet(
+		onDismissRequest = onDismissRequest,
+	) {
+		content(
+			Modifier.padding(16.dp)
+				.navigationBarsPadding(),
+		)
+	}
+}

--- a/app/src/main/kotlin/com/intive/picover/parties/view/AddPartyContent.kt
+++ b/app/src/main/kotlin/com/intive/picover/parties/view/AddPartyContent.kt
@@ -5,8 +5,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.material3.Button
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -22,21 +20,20 @@ import androidx.compose.ui.tooling.preview.datasource.LoremIpsum
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import com.intive.picover.R
+import com.intive.picover.common.bottomsheet.PicoverModalBottomSheet
 import com.intive.picover.common.text.PicoverOutlinedTextField
 import com.intive.picover.common.validator.TextValidator
 import com.intive.picover.parties.viewmodel.PartiesViewModel
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AddPartyBottomSheet(
 	viewModel: PartiesViewModel,
 	navController: NavHostController,
 ) {
 	val state by viewModel.state
-	ModalBottomSheet(
-		onDismissRequest = { navController.popBackStack() },
-	) {
+	PicoverModalBottomSheet(onDismissRequest = { navController.popBackStack() }) { bottomSheetModifier ->
 		AddPartyContent(
+			modifier = bottomSheetModifier,
 			title = state.title,
 			onTitleChange = { viewModel.updateTitle(it) },
 			description = state.description,
@@ -48,6 +45,7 @@ fun AddPartyBottomSheet(
 
 @Composable
 fun AddPartyContent(
+	modifier: Modifier,
 	title: String,
 	onTitleChange: (String) -> Unit,
 	description: String,
@@ -56,7 +54,7 @@ fun AddPartyContent(
 ) {
 	val focusManager = LocalFocusManager.current
 	Column(
-		Modifier.padding(16.dp),
+		modifier = modifier,
 		horizontalAlignment = Alignment.CenterHorizontally,
 	) {
 		PicoverOutlinedTextField(
@@ -85,7 +83,6 @@ fun AddPartyContent(
 			maxLines = 3,
 		)
 		Button(
-			modifier = Modifier,
 			onClick = onSaveButtonClick,
 		) {
 			Text(
@@ -100,6 +97,7 @@ fun AddPartyContent(
 @Composable
 private fun AddPartyContentValidPreview() {
 	AddPartyContent(
+		modifier = Modifier,
 		title = LoremIpsum(4).values.first(),
 		onTitleChange = {},
 		description = LoremIpsum(15).values.first(),
@@ -112,6 +110,7 @@ private fun AddPartyContentValidPreview() {
 @Composable
 private fun AddPartyContentInvalidPreview() {
 	AddPartyContent(
+		modifier = Modifier,
 		title = LoremIpsum(6).values.first(),
 		onTitleChange = {},
 		description = LoremIpsum(20).values.first(),

--- a/app/src/main/kotlin/com/intive/picover/profile/view/ProfileUpdateBottomSheet.kt
+++ b/app/src/main/kotlin/com/intive/picover/profile/view/ProfileUpdateBottomSheet.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.Close
@@ -12,7 +11,6 @@ import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -21,12 +19,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import com.intive.picover.R
+import com.intive.picover.common.bottomsheet.PicoverModalBottomSheet
 import com.intive.picover.common.text.PicoverOutlinedTextField
 import com.intive.picover.common.validator.TextValidator
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ProfileUpdateBottomSheet(
 	username: String,
@@ -35,9 +32,32 @@ fun ProfileUpdateBottomSheet(
 	onUsernameChange: (String) -> Unit,
 ) {
 	var isUserNameValid by remember { mutableStateOf(true) }
-	ModalBottomSheet(
-		modifier = Modifier.padding(bottom = 56.dp),
-		onDismissRequest = onClose,
+	PicoverModalBottomSheet(onDismissRequest = onClose) { bottomSheetModifier ->
+		ProfileUpdateContent(
+			modifier = bottomSheetModifier,
+			onClose = onClose,
+			onSaveClick = onSaveClick,
+			username = username,
+			onUsernameChange = onUsernameChange,
+			isUserNameValid = isUserNameValid,
+			onValidationStatusChange = { isUserNameValid = it },
+		)
+	}
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ProfileUpdateContent(
+	modifier: Modifier,
+	onClose: () -> Unit,
+	onSaveClick: () -> Unit,
+	username: String,
+	onUsernameChange: (String) -> Unit,
+	isUserNameValid: Boolean,
+	onValidationStatusChange: (Boolean) -> Unit,
+) {
+	Column(
+		modifier = modifier,
 	) {
 		Row(horizontalArrangement = Arrangement.SpaceAround) {
 			CenterAlignedTopAppBar(
@@ -68,19 +88,13 @@ fun ProfileUpdateBottomSheet(
 				},
 			)
 		}
-		Column(
-			modifier = Modifier
-				.padding(start = 20.dp, end = 20.dp, bottom = 42.dp)
-				.fillMaxWidth(),
-		) {
-			PicoverOutlinedTextField(
-				modifier = Modifier.fillMaxWidth(),
-				value = username,
-				onValueChange = onUsernameChange,
-				validator = TextValidator.Short,
-				labelText = stringResource(id = R.string.UserName),
-				onValidationStatusChange = { isUserNameValid = it },
-			)
-		}
+		PicoverOutlinedTextField(
+			modifier = Modifier.fillMaxWidth(),
+			value = username,
+			onValueChange = onUsernameChange,
+			validator = TextValidator.Short,
+			labelText = stringResource(id = R.string.UserName),
+			onValidationStatusChange = onValidationStatusChange,
+		)
 	}
 }


### PR DESCRIPTION
Closes #444 

Examples:

Api 28
![api28](https://github.com/Android-Guild/Picover/assets/33199010/f3143fa1-dd37-46f2-9b86-d59ca5dadc42)

Api 33 (physical device) 3 navigation button
![api33-3buttons](https://github.com/Android-Guild/Picover/assets/33199010/1371bc66-0a2e-4e31-bd04-4847b6dd9f1d)

Api 33 (physical device) gesture navigation
![api33-gestures](https://github.com/Android-Guild/Picover/assets/33199010/87966f4b-b950-4cf3-bffd-12fe90055ff8)
